### PR TITLE
Fixed params Id error

### DIFF
--- a/src/app/article/[id]/page.tsx
+++ b/src/app/article/[id]/page.tsx
@@ -1,12 +1,12 @@
 import { notFound } from "next/navigation";
 
 interface Props {
-  params: { id?: string };
+  params: Promise<{ id?: string }>;
 }
 
 export default async function ArticlePage({ params }: Props) {
   // `params` を非同期に取得する
-  const id = await Promise.resolve(params.id);
+  const { id } = await params;
 
   console.log("Fetching article ID:", id);
 


### PR DESCRIPTION
params Id エラーを修正して下記警告を解決
```
page.tsx:9  Server   Error: Route "/article/[id]" used params.id. params should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
    at ArticlePage (page.tsx:9:43)
```