### PR TITLE
fixed get api data add ful_text

### DIFF
--- a/src/app/article/[id]/articleData.py
+++ b/src/app/article/[id]/articleData.py
@@ -12,6 +12,10 @@ soup = BeautifulSoup(response.text, 'html.parser')
 title = soup.title.string
 print(f"ページのタイトル: {title}")
 
+#記事の全体を取得
+full_text = soup.get_text(strip=True)
+print("ページ全体のテキスト:", full_text)
+
 # すべてのリンクを取得
 links = soup.find_all('a')
 for link in links:

--- a/src/app/article/[id]/page.tsx
+++ b/src/app/article/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-
+import link from "./articleData";
 interface Props {
   params: Promise<{ id?: string }>;
 }


### PR DESCRIPTION
### 1. **変更の概要**
- 記事全体のテキストデータを取得
`full_text = soup.get_text(strip=True)
print("ページ全体のテキスト:", full_text)`

### 2. **なぜこの変更をするのか**
- contentsで取得できなかったため、full-textで全体を取得した
### 3. **課題**
- 取得したデータの加工方法
    - 現在はすべてのテキストを取得しているが、どこまで使うか
    - 画像の取り扱い
    - テキスト中のリンクの取り扱い
- 加工済みデータのフロントへの渡し方
### 4. **備考**
- ない